### PR TITLE
ci: improve workflow reliability and add cargo-binstall caching

### DIFF
--- a/.github/actions/cargo-binstall/action.yaml
+++ b/.github/actions/cargo-binstall/action.yaml
@@ -1,0 +1,44 @@
+name: cargo-binstall
+description: Use cargo-binstall to install cargo binaries
+inputs:
+  binaries:
+    description: The binaries to install
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Hash binaries
+      id: hash-binaries
+      shell: bash
+      run: |
+        if command -v sha256sum >/dev/null 2>&1; then
+          hash=$(echo "${{ inputs.binaries }}" | sha256sum | awk '{print $1}')
+        else
+          hash=$(echo "${{ inputs.binaries }}" | shasum -a 256 | awk '{print $1}')
+        fi
+        echo "binaries-hash=$hash" >> $GITHUB_OUTPUT
+    - uses: actions/cache@v4
+      name: Cache Cargo binaries
+      id: cache-cargo-binaries
+      with:
+        key: cargo-binaries-${{ steps.hash-binaries.outputs.binaries-hash }}-${{ runner.os }}-${{ runner.arch }}
+        path: |
+          ~/.cargo/bin/
+    - name: Find missing binaries
+      id: find-missing-binaries
+      shell: bash
+      run: |
+        missing_binaries=()
+        for binary in ${{ inputs.binaries }}; do
+          if ! command -v $binary &> /dev/null; then
+            missing_binaries+=($binary)
+          fi
+        done
+        echo "missing_binaries=${missing_binaries[*]}" >> $GITHUB_OUTPUT
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
+      if: steps.find-missing-binaries.outputs.missing_binaries != ''
+    - name: Install missing binaries
+      if: steps.find-missing-binaries.outputs.missing_binaries != ''
+      shell: bash
+      run: cargo binstall --no-confirm ${{ steps.find-missing-binaries.outputs.missing_binaries }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           cache-name: check
       - uses: ./.github/actions/cargo-hold-install
-      - run: cargo check --all-targets
+      - run: cargo check --locked --all-targets
 
   test:
     runs-on: ${{ matrix.os }}
@@ -47,11 +47,10 @@ jobs:
         with:
           cache-name: test
       - uses: ./.github/actions/cargo-hold-install
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install cargo-nextest
-        run: cargo binstall --no-confirm cargo-nextest
-      - run: cargo nextest run --profile ci
+      - uses: ./.github/actions/cargo-binstall
+        with:
+          binaries: cargo-nextest
+      - run: cargo nextest run --locked --profile ci
 
   doctest:
     runs-on: ${{ matrix.os }}
@@ -66,7 +65,7 @@ jobs:
         with:
           cache-name: doctest
       - uses: ./.github/actions/cargo-hold-install
-      - run: cargo test --doc
+      - run: cargo test --locked --doc
 
   clippy:
     runs-on: ubuntu-latest
@@ -90,20 +89,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install cargo-deny
-        run: cargo binstall --no-confirm cargo-deny
+      - uses: ./.github/actions/cargo-binstall
+        with:
+          binaries: cargo-deny
       - run: cargo deny check
 
   audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install cargo-audit
-        run: cargo binstall --no-confirm cargo-audit
+      - uses: ./.github/actions/cargo-binstall
+        with:
+          binaries: cargo-audit
       - run: cargo audit
 
   cross-build:

--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -109,6 +109,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload cache misses to Nix cache
+        if: always()
         run: |
           # Check if we have any locally built paths to upload
           if [ -f /tmp/locally-built-paths.txt ] && [ -s /tmp/locally-built-paths.txt ]; then

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
       - v*
 env:
   CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   contents: write
@@ -24,11 +25,10 @@ jobs:
         with:
           cache-name: publish-test
       - uses: ./.github/actions/cargo-hold-install
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install cargo-nextest
-        run: cargo binstall --no-confirm cargo-nextest
-      - run: cargo nextest run --profile ci
+      - uses: ./.github/actions/cargo-binstall
+        with:
+          binaries: cargo-nextest
+      - run: cargo nextest run --locked --profile ci
 
   cross-build:
     needs: [test]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ The project uses GitHub Actions with:
 - Always run `cargo clippy` before committing
 - Use `cargo +nightly fmt` for formatting (project uses 2024 style edition)
 - Check licenses with `cargo deny check` when adding dependencies
+- Use conventional commits-style commit messages https://www.conventionalcommits.org/en/v1.0.0/
 
 ## Error Handling Guidelines
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-hold"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_fs",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "cargo-hold"
 readme = "README.md"
 repository = "https://github.com/Ellipsis-labs/cargo-hold"
 rust-version = "1.88.0"
-version = "1.0.0"
+version = "1.0.1"
 
 [[bin]]
 name = "cargo-hold"


### PR DESCRIPTION
- Add --locked flag to all cargo commands for reproducible builds
- Create reusable cargo-binstall action with caching support
- Refactor workflows to use the new cargo-binstall action
- Add GITHUB_TOKEN to publish workflow environment
- Ensure Nix cache upload runs even on failure in cross-build
- Bump version to 1.0.1