### PR TITLE
stop deleting cargo credentials during gc

### DIFF
--- a/src/gc/cargo.rs
+++ b/src/gc/cargo.rs
@@ -21,22 +21,6 @@ pub(crate) fn clean_cargo_registry_with_home(
 ) -> Result<CargoRegistryStats> {
     let mut stats = CargoRegistryStats::default();
 
-    // Remove credentials
-    let credentials_file = cargo_home.join("credentials.toml");
-    if credentials_file.exists() {
-        if !config.quiet() && verbose > 0 {
-            eprintln!("Removing cargo credentials");
-        }
-        let size = fs::metadata(&credentials_file)
-            .map(|m| m.len())
-            .unwrap_or(0);
-        if !config.dry_run() {
-            let _ = fs::remove_file(&credentials_file);
-        }
-        stats.bytes_freed += size;
-        stats.files_removed = stats.files_removed.saturating_add(1);
-    }
-
     // Clean old registry cache files
     let registry_cache = cargo_home.join("registry").join("cache");
     if registry_cache.exists() {

--- a/tests/the_tests/cargo_cleanup_test.rs
+++ b/tests/the_tests/cargo_cleanup_test.rs
@@ -52,6 +52,31 @@ fn test_clean_cargo_registry_with_mock_home() {
 }
 
 #[test]
+fn test_clean_cargo_registry_preserves_credentials_toml() {
+    let home = TempHomeGuard::new();
+    let cargo_home = home.cargo_home();
+
+    let credentials = cargo_home.join("credentials.toml");
+    fs::write(&credentials, "[registry]\ntoken = \"do-not-delete\"\n").unwrap();
+
+    let config = Gc::builder()
+        .target_dir(home.home().join("target"))
+        .dry_run(false)
+        .debug(false)
+        .age_threshold_days(7)
+        .build();
+
+    config
+        .clean_cargo_registry_with_home(&cargo_home, 0)
+        .unwrap();
+
+    assert!(
+        credentials.exists(),
+        "cargo-hold must never delete ~/.cargo/credentials.toml; it stores private registry tokens"
+    );
+}
+
+#[test]
 fn test_clean_cargo_bin_with_mock_home() {
     // Create a temporary directory to act as cargo home
     let home = TempHomeGuard::new();


### PR DESCRIPTION
## what changed

clean_cargo_registry_with_home used to unconditionally remove ~/.cargo/credentials.toml. That file holds **private registry tokens** (crates.io, GitHub Packages, private registries, etc.). Running cargo hold heave or cargo hold voyage would silently wipe it, breaking logins and CI access to private crates.

This removes that behavior entirely. GC should trim old cache files, not destroy auth.

## testing

Added 	est_clean_cargo_registry_preserves_credentials_toml so we do not regress.

---

made by mooncitydev
