### PR TITLE
ci: use crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,11 +6,9 @@ on:
       - v*
 env:
   CARGO_TERM_COLOR: always
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
-  contents: write
-  discussions: write
+  contents: read
 
 jobs:
   test:
@@ -40,10 +38,18 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [cross-build]
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - run: echo ${{ secrets.CRATES_IO_TOKEN }} | cargo login
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Switch the publish workflow from a long-lived `CRATES_IO_TOKEN` login flow to crates.io trusted publishing via GitHub OIDC.

## User Impact

Releases no longer depend on a stored crates.io API token in GitHub secrets. Publishing is limited to the trusted GitHub workflow identity configured on crates.io, which reduces credential exposure while keeping the release flow unchanged for maintainers.

## Root Cause

The publish job authenticated with `cargo login` using `secrets.CRATES_IO_TOKEN`, which relied on a long-lived shared credential and broader workflow-level write permissions.

## Fix

Use `rust-lang/crates-io-auth-action@v1` to exchange the job OIDC token for a short-lived crates.io token, pass it through `CARGO_REGISTRY_TOKEN`, and scope `id-token: write` plus the existing write permissions to the publish job instead of the whole workflow.

## Validation

Ran `npx prettier --check .github/workflows/publish.yaml`.
