### PR TITLE
fix ci failures when salvage/stow skip files and heave eats restored cache

### DIFF
--- a/src/commands/salvage.rs
+++ b/src/commands/salvage.rs
@@ -137,11 +137,17 @@ fn analyze_files(
         }
     }
 
-    if !errors.is_empty() && !log.quiet() {
-        eprintln!("Warning: Failed to analyze {} file(s)", errors.len());
-        if log.level() == 0 {
-            eprintln!("Run with -v for more details");
+    if !errors.is_empty() {
+        if !log.quiet() {
+            eprintln!("Warning: Failed to analyze {} file(s)", errors.len());
+            if log.level() == 0 {
+                eprintln!("Run with -v for more details");
+            }
         }
+        return Err(crate::error::HoldError::PartialFileProcessing {
+            failed: errors.len(),
+            total: tracked_files.len(),
+        });
     }
 
     Ok((unchanged, modified, added))

--- a/src/commands/salvage.rs
+++ b/src/commands/salvage.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use rayon::prelude::*;
 
 use crate::discovery::discover_tracked_files;
-use crate::error::Result;
+use crate::error::{HoldError, Result};
 use crate::hashing::{get_file_size, hash_file};
 use crate::logging::Logger;
 use crate::metadata::load_metadata;
@@ -39,7 +39,12 @@ pub fn salvage(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Pat
 
     let new_mtime = generate_monotonic_timestamp(&metadata);
 
-    let (repo_root, tracked_files, symlink_count) = discover_tracked_files(working_dir)?;
+    let discovered = discover_tracked_files(working_dir)?;
+    let total_processable = discovered.processable_count();
+    let repo_root = discovered.repo_root;
+    let tracked_files = discovered.files;
+    let symlink_count = discovered.symlink_count;
+    let inaccessible_files = discovered.inaccessible_files;
 
     if !log.quiet() && symlink_count > 0 {
         eprintln!(
@@ -47,6 +52,28 @@ pub fn salvage(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Pat
             symlink_count,
             if symlink_count == 1 { "" } else { "s" }
         );
+    }
+
+    if !inaccessible_files.is_empty() {
+        if !log.quiet() {
+            eprintln!(
+                "Warning: Failed to access {} tracked file(s)",
+                inaccessible_files.len()
+            );
+            for path in &inaccessible_files {
+                log.verbose(
+                    1,
+                    format!("  Could not access tracked file: {}", path.display()),
+                );
+            }
+            if log.level() == 0 {
+                eprintln!("Run with -v for more details");
+            }
+        }
+        return Err(HoldError::PartialFileProcessing {
+            failed: inaccessible_files.len(),
+            total: total_processable,
+        });
     }
 
     let (unchanged, modified, added) =

--- a/src/commands/stow.rs
+++ b/src/commands/stow.rs
@@ -56,11 +56,17 @@ pub fn stow(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Path) 
         }
     }
 
-    if errors > 0 && !log.quiet() {
-        eprintln!("Warning: Failed to analyze {errors} file(s)");
-        if log.level() == 0 {
-            eprintln!("Run with -v for more details");
+    if errors > 0 {
+        if !log.quiet() {
+            eprintln!("Warning: Failed to analyze {errors} file(s)");
+            if log.level() == 0 {
+                eprintln!("Run with -v for more details");
+            }
         }
+        return Err(HoldError::PartialFileProcessing {
+            failed: errors,
+            total: tracked_files.len(),
+        });
     }
 
     let existing_metadata = match load_metadata(metadata_path) {

--- a/src/commands/stow.rs
+++ b/src/commands/stow.rs
@@ -18,7 +18,12 @@ pub fn stow(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Path) 
     let log = Logger::new(verbose, quiet);
     log.verbose(1, "Stowing files in cargo hold...");
 
-    let (repo_root, tracked_files, symlink_count) = discover_tracked_files(working_dir)?;
+    let discovered = discover_tracked_files(working_dir)?;
+    let total_processable = discovered.processable_count();
+    let repo_root = discovered.repo_root;
+    let tracked_files = discovered.files;
+    let symlink_count = discovered.symlink_count;
+    let inaccessible_files = discovered.inaccessible_files;
 
     log.verbose(1, format!("Found {} tracked files", tracked_files.len()));
 
@@ -30,13 +35,23 @@ pub fn stow(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Path) 
         );
     }
 
+    let mut errors = inaccessible_files.len();
+    if errors > 0 && !log.quiet() {
+        eprintln!("Warning: Failed to access {errors} tracked file(s)");
+        for path in &inaccessible_files {
+            log.verbose(
+                1,
+                format!("  Could not access tracked file: {}", path.display()),
+            );
+        }
+    }
+
     let file_states: Vec<Result<FileState>> = tracked_files
         .par_iter()
         .map(|path| build_file_state(&repo_root, path))
         .collect();
 
     let mut new_metadata = StateMetadata::new();
-    let mut errors = 0;
     for result in file_states {
         match result {
             Ok(state) => {
@@ -65,7 +80,7 @@ pub fn stow(metadata_path: &Path, verbose: u8, quiet: bool, working_dir: &Path) 
         }
         return Err(HoldError::PartialFileProcessing {
             failed: errors,
-            total: tracked_files.len(),
+            total: total_processable,
         });
     }
 

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -40,6 +40,24 @@ fn test_stow_command() {
 }
 
 #[test]
+fn test_stow_fails_when_tracked_file_is_missing() {
+    let temp_dir = setup_git_repo();
+    let metadata_path = temp_dir.path().join("test.metadata");
+
+    fs::remove_file(temp_dir.path().join("test.txt")).unwrap();
+
+    let err = stow(&metadata_path, 0, true, temp_dir.path()).unwrap_err();
+    assert!(matches!(
+        err,
+        HoldError::PartialFileProcessing {
+            failed: 1,
+            total: 1,
+        }
+    ));
+    assert!(!metadata_path.exists());
+}
+
+#[test]
 fn test_stow_from_subdirectory() {
     let temp_dir = setup_git_repo();
 
@@ -72,6 +90,24 @@ fn test_salvage_from_subdirectory() {
 
     // Now run salvage from subdirectory
     salvage(&metadata_path, 0, false, &subdir).unwrap();
+}
+
+#[test]
+fn test_salvage_fails_when_tracked_file_is_missing() {
+    let temp_dir = setup_git_repo();
+    let metadata_path = temp_dir.path().join("test.metadata");
+
+    stow(&metadata_path, 0, true, temp_dir.path()).unwrap();
+    fs::remove_file(temp_dir.path().join("test.txt")).unwrap();
+
+    let err = salvage(&metadata_path, 0, true, temp_dir.path()).unwrap_err();
+    assert!(matches!(
+        err,
+        HoldError::PartialFileProcessing {
+            failed: 1,
+            total: 1,
+        }
+    ));
 }
 
 #[test]

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -4,6 +4,25 @@ use git2::{Index, Repository};
 
 use crate::error::HoldError;
 
+/// Files discovered from the Git index.
+pub(crate) struct TrackedFiles {
+    /// Repository root path.
+    pub(crate) repo_root: PathBuf,
+    /// Tracked regular files that can be processed.
+    pub(crate) files: Vec<PathBuf>,
+    /// Number of tracked symbolic links skipped intentionally.
+    pub(crate) symlink_count: usize,
+    /// Tracked paths that could not be accessed on disk.
+    pub(crate) inaccessible_files: Vec<PathBuf>,
+}
+
+impl TrackedFiles {
+    /// Number of tracked paths that should have been processable.
+    pub(crate) fn processable_count(&self) -> usize {
+        self.files.len() + self.inaccessible_files.len()
+    }
+}
+
 /// Discovers all tracked files in the Git repository.
 ///
 /// This function uses the Git index to find all files that are tracked by Git,
@@ -29,9 +48,7 @@ use crate::error::HoldError;
 /// - No Git repository is found at or above the given path
 /// - The Git index cannot be accessed
 /// - Any file path contains invalid UTF-8
-pub fn discover_tracked_files(
-    repo_path: &Path,
-) -> Result<(PathBuf, Vec<PathBuf>, usize), HoldError> {
+pub(crate) fn discover_tracked_files(repo_path: &Path) -> Result<TrackedFiles, HoldError> {
     // Open the repository, searching upward from the given path
     let repo = Repository::discover(repo_path)
         .map_err(|_| HoldError::RepoNotFound(repo_path.to_path_buf()))?;
@@ -46,18 +63,25 @@ pub fn discover_tracked_files(
     let index = repo.index().map_err(HoldError::IndexError)?;
 
     // Collect all tracked file paths, filtering out symlinks
-    let (tracked_files, symlink_count) = collect_index_paths(&index, &repo_root)?;
+    let (tracked_files, symlink_count, inaccessible_files) =
+        collect_index_paths(&index, &repo_root)?;
 
-    Ok((repo_root, tracked_files, symlink_count))
+    Ok(TrackedFiles {
+        repo_root,
+        files: tracked_files,
+        symlink_count,
+        inaccessible_files,
+    })
 }
 
 /// Extract all file paths from the Git index, filtering out symlinks
 fn collect_index_paths(
     index: &Index,
     repo_root: &Path,
-) -> Result<(Vec<PathBuf>, usize), HoldError> {
+) -> Result<(Vec<PathBuf>, usize, Vec<PathBuf>), HoldError> {
     let mut paths = Vec::new();
     let mut symlink_count = 0;
+    let mut inaccessible_paths = Vec::new();
 
     for entry in index.iter() {
         // Skip submodules (mode 160000) - they appear as directories in the filesystem
@@ -85,20 +109,16 @@ fn collect_index_paths(
                     continue; // Skip symlinks
                 }
             }
-            Err(e) => {
-                eprintln!(
-                    "Warning: Could not access file '{}': {}. Skipping.",
-                    full_path.display(),
-                    e
-                );
-                continue; // Skip files we can't access
+            Err(_) => {
+                inaccessible_paths.push(path_buf);
+                continue; // Report files we can't access to the caller.
             }
         }
 
         paths.push(path_buf);
     }
 
-    Ok((paths, symlink_count))
+    Ok((paths, symlink_count, inaccessible_paths))
 }
 
 #[cfg(test)]
@@ -129,15 +149,32 @@ mod tests {
     fn test_discover_tracked_files() {
         let (temp_dir, _repo) = setup_test_repo();
 
-        let (repo_root, files, symlink_count) = discover_tracked_files(temp_dir.path()).unwrap();
+        let discovered = discover_tracked_files(temp_dir.path()).unwrap();
         // On macOS, /var is a symlink to /private/var, so we need to canonicalize paths
         assert_eq!(
-            repo_root.canonicalize().unwrap(),
+            discovered.repo_root.canonicalize().unwrap(),
             temp_dir.path().canonicalize().unwrap()
         );
-        assert_eq!(files.len(), 1);
-        assert!(files[0].ends_with("test.txt"));
-        assert_eq!(symlink_count, 0);
+        assert_eq!(discovered.files.len(), 1);
+        assert!(discovered.files[0].ends_with("test.txt"));
+        assert_eq!(discovered.symlink_count, 0);
+        assert!(discovered.inaccessible_files.is_empty());
+        assert_eq!(discovered.processable_count(), 1);
+    }
+
+    #[test]
+    fn test_discover_tracked_files_reports_missing_tracked_files() {
+        let (temp_dir, _repo) = setup_test_repo();
+        fs::remove_file(temp_dir.path().join("test.txt")).unwrap();
+
+        let discovered = discover_tracked_files(temp_dir.path()).unwrap();
+
+        assert!(discovered.files.is_empty());
+        assert_eq!(
+            discovered.inaccessible_files,
+            vec![PathBuf::from("test.txt")]
+        );
+        assert_eq!(discovered.processable_count(), 1);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -220,14 +220,13 @@ pub enum HoldError {
         String,
     ),
 
-    /// One or more tracked files could not be hashed or read during stow/salvage.
+    /// One or more tracked files could not be hashed or read during
+    /// stow/salvage.
     ///
     /// The command stops instead of writing partial metadata or restoring
-    /// timestamps for only a subset of files, which would make CI report success
-    /// while incremental compilation state is wrong.
-    #[error(
-        "failed to process {failed} of {total} tracked file(s); run with -v for details"
-    )]
+    /// timestamps for only a subset of files, which would make CI report
+    /// success while incremental compilation state is wrong.
+    #[error("failed to process {failed} of {total} tracked file(s); run with -v for details")]
     #[diagnostic(
         code(cargo_hold::files::partial_failure),
         help("Fix file permissions or paths, then re-run the command.")

--- a/src/error.rs
+++ b/src/error.rs
@@ -220,6 +220,25 @@ pub enum HoldError {
         String,
     ),
 
+    /// One or more tracked files could not be hashed or read during stow/salvage.
+    ///
+    /// The command stops instead of writing partial metadata or restoring
+    /// timestamps for only a subset of files, which would make CI report success
+    /// while incremental compilation state is wrong.
+    #[error(
+        "failed to process {failed} of {total} tracked file(s); run with -v for details"
+    )]
+    #[diagnostic(
+        code(cargo_hold::files::partial_failure),
+        help("Fix file permissions or paths, then re-run the command.")
+    )]
+    PartialFileProcessing {
+        /// Number of files that failed
+        failed: usize,
+        /// Total tracked files attempted
+        total: usize,
+    },
+
     /// PathBuf cannot be converted to UTF-8 string for storage.
     ///
     /// Raised in StateMetadata operations when a PathBuf contains

--- a/src/gc/artifacts.rs
+++ b/src/gc/artifacts.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use super::size::format_size;
 use crate::error::{HoldError, Result};
 use crate::logging::Logger;
-use crate::timestamp::saturating_duration_from_nanos;
+use crate::timestamp::{saturating_duration_from_nanos, set_file_mtime};
 
 /// Information about a single artifact
 #[derive(Debug, Clone)]
@@ -188,6 +188,122 @@ fn add_artifact_file(path: &Path, crate_artifact: &mut CrateArtifact) -> Result<
     Ok(())
 }
 
+/// Cutoff used to decide whether an artifact belongs to the previous CI build.
+///
+/// Returns `None` when previous-build preservation should be skipped entirely.
+pub(crate) fn previous_build_preservation_cutoff(
+    previous_build_mtime_nanos: Option<u128>,
+    age_threshold_days: u32,
+) -> Option<SystemTime> {
+    let previous_mtime_nanos = previous_build_mtime_nanos?;
+    if age_threshold_days == 0 {
+        return None;
+    }
+
+    let (duration, saturated) = saturating_duration_from_nanos(previous_mtime_nanos);
+    if saturated {
+        eprintln!(
+            "Warning: previous_build_mtime_nanos ({previous_mtime_nanos}) exceeds representable \
+             range; clamping to ~year 2554."
+        );
+    }
+    let mut previous_mtime = SystemTime::UNIX_EPOCH + duration;
+    let now = SystemTime::now();
+    if previous_mtime > now {
+        previous_mtime = now;
+    }
+
+    let age_threshold =
+        std::time::Duration::from_secs(age_threshold_days as u64 * 24 * 60 * 60);
+    let elapsed_since_previous = now
+        .duration_since(previous_mtime)
+        .unwrap_or(std::time::Duration::ZERO);
+
+    if elapsed_since_previous > age_threshold {
+        return None;
+    }
+
+    let buffer = std::time::Duration::from_secs(5 * 60);
+    Some(
+        previous_mtime
+            .checked_sub(buffer)
+            .unwrap_or(SystemTime::UNIX_EPOCH),
+    )
+}
+
+/// Refresh artifact mtimes when a restored CI cache has filesystem times older
+/// than the last `heave` run.
+///
+/// GitHub Actions and similar caches often unpack with stale mtimes. Without
+/// this pass, `heave` treats every artifact as ancient and deletes the cache
+/// you just restored.
+pub(crate) fn rejuvenate_stale_artifact_mtimes(
+    artifacts: &mut [CrateArtifact],
+    previous_build_mtime_nanos: Option<u128>,
+    age_threshold_days: u32,
+    dry_run: bool,
+    verbose: u8,
+    quiet: bool,
+) -> Result<usize> {
+    let log = Logger::new(verbose, quiet);
+    let Some(cutoff) =
+        previous_build_preservation_cutoff(previous_build_mtime_nanos, age_threshold_days)
+    else {
+        return Ok(0);
+    };
+
+    if artifacts.is_empty() {
+        return Ok(0);
+    }
+
+    let matching = artifacts
+        .iter()
+        .filter(|artifact| artifact.newest_mtime >= cutoff)
+        .count();
+
+    if matching > 0 {
+        return Ok(0);
+    }
+
+    if !log.quiet() {
+        eprintln!(
+            "  Restored cache has stale artifact mtimes (none newer than last heave); \
+             refreshing timestamps before GC"
+        );
+    }
+
+    let refresh_time = SystemTime::now();
+    let mut files_touched = 0usize;
+
+    if dry_run {
+        return Ok(artifacts.iter().map(|a| a.artifacts.len()).sum());
+    }
+
+    for artifact in artifacts.iter_mut() {
+        let mut newest = SystemTime::UNIX_EPOCH;
+        for info in &mut artifact.artifacts {
+            if info.path.is_file() {
+                set_file_mtime(&info.path, refresh_time)?;
+                info._modified = refresh_time;
+                files_touched += 1;
+                if refresh_time > newest {
+                    newest = refresh_time;
+                }
+            }
+        }
+        if newest > artifact.newest_mtime {
+            artifact.newest_mtime = newest;
+        }
+    }
+
+    log.verbose(
+        1,
+        format!("  Refreshed mtimes on {files_touched} artifact file(s)"),
+    );
+
+    Ok(files_touched)
+}
+
 /// Select artifacts to remove based on both size and age constraints
 ///
 /// This function implements a two-phase cleanup strategy:
@@ -247,71 +363,34 @@ fn preserve_previous_build_artifacts(
 ) -> Vec<&CrateArtifact> {
     let log = Logger::new(verbose, quiet);
     if let Some(previous_mtime_nanos) = previous_build_mtime_nanos {
-        let (duration, saturated) = saturating_duration_from_nanos(previous_mtime_nanos);
-        if saturated && !log.quiet() {
-            eprintln!(
-                "Warning: previous_build_mtime_nanos ({previous_mtime_nanos}) exceeds \
-                 representable range; clamping to ~year 2554.",
-            );
-        }
+        if let Some(cutoff_time) =
+            previous_build_preservation_cutoff(Some(previous_mtime_nanos), age_threshold_days)
+        {
+            let (preserved, eligible): (Vec<_>, Vec<_>) = artifacts
+                .into_iter()
+                .partition(|artifact| artifact.newest_mtime >= cutoff_time);
 
-        let mut previous_mtime = SystemTime::UNIX_EPOCH + duration;
-        let now = SystemTime::now();
-        if previous_mtime > now {
-            previous_mtime = now;
-        }
-
-        if age_threshold_days == 0 {
-            log.verbose(
-                2,
-                "  Skipping previous build preservation because age threshold is 0 days",
-            );
-            return artifacts;
-        }
-
-        let age_threshold =
-            std::time::Duration::from_secs(age_threshold_days as u64 * 24 * 60 * 60);
-        let elapsed_since_previous = now
-            .duration_since(previous_mtime)
-            .unwrap_or(std::time::Duration::ZERO);
-
-        if elapsed_since_previous > age_threshold {
-            log.verbose(
-                1,
-                format!(
-                    "  Previous build timestamp is {elapsed_since_previous:?} old; exceeding \
-                     threshold, skipping preservation"
-                ),
-            );
-            return artifacts;
-        }
-
-        // Add a generous buffer to account for clock drift and build finishing before
-        // GC.
-        let buffer = std::time::Duration::from_secs(5 * 60);
-        let cutoff_time = previous_mtime
-            .checked_sub(buffer)
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-
-        let (preserved, eligible): (Vec<_>, Vec<_>) = artifacts
-            .into_iter()
-            .partition(|artifact| artifact.newest_mtime >= cutoff_time);
-
-        if !log.quiet() && !preserved.is_empty() {
-            let preserved_size: u64 = preserved.iter().map(|a| a.total_size).sum();
-            eprintln!(
-                "  Preserving {} artifacts ({}) from previous build",
-                preserved.len(),
-                format_size(preserved_size)
-            );
-            if log.level() > 1 {
-                for artifact in &preserved {
-                    eprintln!("    Preserving: {}-{}", artifact.name, artifact.hash);
+            if !log.quiet() && !preserved.is_empty() {
+                let preserved_size: u64 = preserved.iter().map(|a| a.total_size).sum();
+                eprintln!(
+                    "  Preserving {} artifacts ({}) from previous build",
+                    preserved.len(),
+                    format_size(preserved_size)
+                );
+                if log.level() > 1 {
+                    for artifact in &preserved {
+                        eprintln!("    Preserving: {}-{}", artifact.name, artifact.hash);
+                    }
                 }
             }
+
+            return eligible;
         }
 
-        return eligible;
+        log.verbose(
+            1,
+            "  Skipping previous build preservation (no cutoff; age threshold 0 or last heave too old)",
+        );
     }
 
     artifacts

--- a/src/gc/artifacts.rs
+++ b/src/gc/artifacts.rs
@@ -255,44 +255,65 @@ pub(crate) fn rejuvenate_stale_artifact_mtimes(
         return Ok(0);
     }
 
-    let matching = artifacts
+    if artifacts
         .iter()
-        .filter(|artifact| artifact.newest_mtime >= cutoff)
-        .count();
+        .any(|artifact| artifact.newest_mtime >= cutoff)
+    {
+        return Ok(0);
+    }
 
-    if matching > 0 {
+    let age_cutoff = SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(
+            age_threshold_days as u64 * 24 * 60 * 60,
+        ))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let refresh_time = SystemTime::now();
+    let mut files_touched = 0usize;
+    let mut crates_refreshed = 0usize;
+
+    for artifact in artifacts.iter_mut() {
+        // Only bump artifacts that look like a recent build with unreliable mtimes.
+        // Truly ancient crates stay old so age/size GC can still evict them.
+        if artifact.newest_mtime < cutoff && artifact.newest_mtime >= age_cutoff {
+            if dry_run {
+                files_touched += artifact
+                    .artifacts
+                    .iter()
+                    .filter(|info| info.path.is_file())
+                    .count();
+                artifact.newest_mtime = refresh_time;
+                crates_refreshed += 1;
+                continue;
+            }
+
+            let mut newest = SystemTime::UNIX_EPOCH;
+            for info in &mut artifact.artifacts {
+                if info.path.is_file() {
+                    set_file_mtime(&info.path, refresh_time)?;
+                    info._modified = refresh_time;
+                    files_touched += 1;
+                    if refresh_time > newest {
+                        newest = refresh_time;
+                    }
+                }
+            }
+            if newest > artifact.newest_mtime {
+                artifact.newest_mtime = newest;
+            }
+            crates_refreshed += 1;
+        }
+    }
+
+    if crates_refreshed == 0 {
         return Ok(0);
     }
 
     if !log.quiet() {
         eprintln!(
-            "  Restored cache has stale artifact mtimes (none newer than last heave); refreshing \
-             timestamps before GC"
+            "  Refreshed mtimes on {crates_refreshed} crate artifact(s) with stale cache \
+             timestamps"
         );
-    }
-
-    let refresh_time = SystemTime::now();
-    let mut files_touched = 0usize;
-
-    if dry_run {
-        return Ok(artifacts.iter().map(|a| a.artifacts.len()).sum());
-    }
-
-    for artifact in artifacts.iter_mut() {
-        let mut newest = SystemTime::UNIX_EPOCH;
-        for info in &mut artifact.artifacts {
-            if info.path.is_file() {
-                set_file_mtime(&info.path, refresh_time)?;
-                info._modified = refresh_time;
-                files_touched += 1;
-                if refresh_time > newest {
-                    newest = refresh_time;
-                }
-            }
-        }
-        if newest > artifact.newest_mtime {
-            artifact.newest_mtime = newest;
-        }
     }
 
     log.verbose(

--- a/src/gc/artifacts.rs
+++ b/src/gc/artifacts.rs
@@ -213,8 +213,7 @@ pub(crate) fn previous_build_preservation_cutoff(
         previous_mtime = now;
     }
 
-    let age_threshold =
-        std::time::Duration::from_secs(age_threshold_days as u64 * 24 * 60 * 60);
+    let age_threshold = std::time::Duration::from_secs(age_threshold_days as u64 * 24 * 60 * 60);
     let elapsed_since_previous = now
         .duration_since(previous_mtime)
         .unwrap_or(std::time::Duration::ZERO);
@@ -267,8 +266,8 @@ pub(crate) fn rejuvenate_stale_artifact_mtimes(
 
     if !log.quiet() {
         eprintln!(
-            "  Restored cache has stale artifact mtimes (none newer than last heave); \
-             refreshing timestamps before GC"
+            "  Restored cache has stale artifact mtimes (none newer than last heave); refreshing \
+             timestamps before GC"
         );
     }
 
@@ -389,7 +388,8 @@ fn preserve_previous_build_artifacts(
 
         log.verbose(
             1,
-            "  Skipping previous build preservation (no cutoff; age threshold 0 or last heave too old)",
+            "  Skipping previous build preservation (no cutoff; age threshold 0 or last heave too \
+             old)",
         );
     }
 

--- a/src/gc/auto_cap.rs
+++ b/src/gc/auto_cap.rs
@@ -56,11 +56,10 @@ pub(crate) fn suggest_max_target_size(
         // If observed growth (based on finals) is within a deadband, hold the cap
         // steady.
         let observed_p90 = percentile(&final_growths, 90);
-        let growth_pct = if baseline == 0 {
-            0
-        } else {
-            observed_p90.saturating_mul(100) / baseline
-        };
+        let growth_pct = observed_p90
+            .saturating_mul(100)
+            .checked_div(baseline)
+            .unwrap_or(0);
 
         if observed_p90 == 0 {
             // No observed positive growth; hold steady when baseline is at/above the cap,

--- a/src/gc/cleanup.rs
+++ b/src/gc/cleanup.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::artifacts::{
-    collect_crate_artifacts, remove_crate_artifacts, select_artifacts_for_removal,
+    collect_crate_artifacts, rejuvenate_stale_artifact_mtimes, remove_crate_artifacts,
+    select_artifacts_for_removal,
 };
 use super::config::{Gc, GcStats};
 use super::size::format_size;
@@ -99,12 +100,21 @@ pub(crate) fn clean_profile_directory(
     }
 
     // Collect and analyze crate artifacts
-    let crate_artifacts = collect_crate_artifacts(profile_dir)?;
+    let mut crate_artifacts = collect_crate_artifacts(profile_dir)?;
 
     log.verbose(
         2,
         format!("  Found {} crate artifacts", crate_artifacts.len()),
     );
+
+    rejuvenate_stale_artifact_mtimes(
+        &mut crate_artifacts,
+        config.previous_build_mtime_nanos(),
+        config.age_threshold_days(),
+        config.dry_run(),
+        verbose,
+        config.quiet(),
+    )?;
 
     // Determine which crates to remove using combined logic
     // Calculate the current total size (initial - already freed globally)

--- a/src/gc/tests.rs
+++ b/src/gc/tests.rs
@@ -853,24 +853,23 @@ fn test_rejuvenate_stale_artifact_mtimes_enables_preservation() {
     let one_hour_ago = now.checked_sub(Duration::from_secs(3600)).unwrap();
     let one_day_ago = now.checked_sub(Duration::from_secs(24 * 3600)).unwrap();
 
-    let mut write_artifact =
-        |name: &str, hash: &str, size: u64, mtime: SystemTime| -> CrateArtifact {
-            let path = deps_dir.join(format!("lib{name}-{hash}.rlib"));
-            let mut file = fs::File::create(&path).unwrap();
-            file.write_all(&vec![0u8; size as usize]).unwrap();
-            set_file_mtime(&path, mtime).unwrap();
-            CrateArtifact {
-                name: name.to_string(),
-                hash: hash.to_string(),
-                artifacts: vec![ArtifactInfo {
-                    path,
-                    size,
-                    _modified: mtime,
-                }],
-                total_size: size,
-                newest_mtime: mtime,
-            }
-        };
+    let write_artifact = |name: &str, hash: &str, size: u64, mtime: SystemTime| -> CrateArtifact {
+        let path = deps_dir.join(format!("lib{name}-{hash}.rlib"));
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(&vec![0u8; size as usize]).unwrap();
+        set_file_mtime(&path, mtime).unwrap();
+        CrateArtifact {
+            name: name.to_string(),
+            hash: hash.to_string(),
+            artifacts: vec![ArtifactInfo {
+                path,
+                size,
+                _modified: mtime,
+            }],
+            total_size: size,
+            newest_mtime: mtime,
+        }
+    };
 
     let mut artifacts = vec![
         write_artifact("stale_recent", "2222222222222222", 4000, one_day_ago),

--- a/src/gc/tests.rs
+++ b/src/gc/tests.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, SystemTime};
 use proptest::prelude::*;
 
 use super::artifacts::{
-    ArtifactInfo, CrateArtifact, parse_crate_artifact_name, select_artifacts_for_removal,
+    ArtifactInfo, CrateArtifact, parse_crate_artifact_name, rejuvenate_stale_artifact_mtimes,
+    select_artifacts_for_removal,
 };
 use super::size::{format_size, parse_size};
 
@@ -833,4 +834,92 @@ fn test_size_cleanup_after_previous_build_expires() {
     assert!(!evicted.is_empty());
     let freed: u64 = evicted.iter().map(|a| a.total_size).sum();
     assert!(freed >= current_size - cap);
+}
+
+#[test]
+fn test_rejuvenate_stale_artifact_mtimes_enables_preservation() {
+    use std::fs;
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use crate::timestamp::set_file_mtime;
+
+    let temp_dir = TempDir::new().unwrap();
+    let deps_dir = temp_dir.path().join("deps");
+    fs::create_dir_all(&deps_dir).unwrap();
+
+    let now = SystemTime::now();
+    let one_hour_ago = now.checked_sub(Duration::from_secs(3600)).unwrap();
+    let one_day_ago = now.checked_sub(Duration::from_secs(24 * 3600)).unwrap();
+
+    let mut write_artifact =
+        |name: &str, hash: &str, size: u64, mtime: SystemTime| -> CrateArtifact {
+            let path = deps_dir.join(format!("lib{name}-{hash}.rlib"));
+            let mut file = fs::File::create(&path).unwrap();
+            file.write_all(&vec![0u8; size as usize]).unwrap();
+            set_file_mtime(&path, mtime).unwrap();
+            CrateArtifact {
+                name: name.to_string(),
+                hash: hash.to_string(),
+                artifacts: vec![ArtifactInfo {
+                    path,
+                    size,
+                    _modified: mtime,
+                }],
+                total_size: size,
+                newest_mtime: mtime,
+            }
+        };
+
+    let mut artifacts = vec![
+        write_artifact("stale_recent", "2222222222222222", 4000, one_day_ago),
+        write_artifact("stale_recent2", "3333333333333333", 3000, one_day_ago),
+        write_artifact("old_artifact", "1111111111111111", 5000, one_day_ago),
+    ];
+
+    let previous_build_nanos = one_hour_ago
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    let before = select_artifacts_for_removal(
+        &artifacts,
+        14000,
+        Some(6000),
+        30,
+        Some(previous_build_nanos),
+        0,
+        true,
+    );
+    assert!(
+        before.iter().any(|a| a.name.starts_with("stale_")),
+        "stale cache mtimes should be selected for removal before rejuvenation"
+    );
+
+    rejuvenate_stale_artifact_mtimes(
+        &mut artifacts,
+        Some(previous_build_nanos),
+        30,
+        false,
+        0,
+        true,
+    )
+    .unwrap();
+
+    let after = select_artifacts_for_removal(
+        &artifacts,
+        14000,
+        Some(6000),
+        30,
+        Some(previous_build_nanos),
+        0,
+        true,
+    );
+    assert!(
+        !after.iter().any(|a| a.name.starts_with("stale_")),
+        "refreshed mtimes should be preserved as previous-build artifacts"
+    );
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].name, "old_artifact");
 }

--- a/src/gc/tests.rs
+++ b/src/gc/tests.rs
@@ -852,6 +852,9 @@ fn test_rejuvenate_stale_artifact_mtimes_enables_preservation() {
     let now = SystemTime::now();
     let one_hour_ago = now.checked_sub(Duration::from_secs(3600)).unwrap();
     let one_day_ago = now.checked_sub(Duration::from_secs(24 * 3600)).unwrap();
+    let forty_days_ago = now
+        .checked_sub(Duration::from_secs(40 * 24 * 3600))
+        .unwrap();
 
     let write_artifact = |name: &str, hash: &str, size: u64, mtime: SystemTime| -> CrateArtifact {
         let path = deps_dir.join(format!("lib{name}-{hash}.rlib"));
@@ -874,7 +877,7 @@ fn test_rejuvenate_stale_artifact_mtimes_enables_preservation() {
     let mut artifacts = vec![
         write_artifact("stale_recent", "2222222222222222", 4000, one_day_ago),
         write_artifact("stale_recent2", "3333333333333333", 3000, one_day_ago),
-        write_artifact("old_artifact", "1111111111111111", 5000, one_day_ago),
+        write_artifact("old_artifact", "1111111111111111", 5000, forty_days_ago),
     ];
 
     let previous_build_nanos = one_hour_ago

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -35,6 +35,32 @@ pub fn saturating_system_time_from_nanos(nanos: u128) -> (SystemTime, bool) {
 use crate::error::{HoldError, Result};
 use crate::state::{FileState, StateMetadata};
 
+/// Reject paths that escape the repository root via `..` or absolute segments.
+pub fn validate_repo_relative_path(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        return Err(HoldError::InvalidPath {
+            message: format!("absolute path not allowed in metadata: {}", path.display()),
+        });
+    }
+
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(HoldError::InvalidPath {
+            message: format!("path escapes repository root: {}", path.display()),
+        });
+    }
+
+    Ok(())
+}
+
+/// Join a repository-relative path to the repo root after validation.
+pub fn repo_relative_path(repo_root: &Path, relative: &Path) -> Result<std::path::PathBuf> {
+    validate_repo_relative_path(relative)?;
+    Ok(repo_root.join(relative))
+}
+
 /// Convert nanoseconds since UNIX_EPOCH to SystemTime
 fn nanos_to_system_time(nanos: u128) -> SystemTime {
     saturating_system_time_from_nanos(nanos).0
@@ -155,6 +181,7 @@ pub fn restore_timestamps(
 ) -> Result<()> {
     // Restore original timestamps for unchanged files
     for file_state in unchanged_files {
+        validate_repo_relative_path(&file_state.path)?;
         let mtime = nanos_to_system_time(file_state.mtime_nanos);
         let full_path = repo_root.join(&file_state.path);
         set_file_mtime(&full_path, mtime)?;
@@ -162,13 +189,13 @@ pub fn restore_timestamps(
 
     // Set new timestamp for modified files
     for path in modified_files {
-        let full_path = repo_root.join(path);
+        let full_path = repo_relative_path(repo_root, path)?;
         set_file_mtime(&full_path, new_mtime)?;
     }
 
     // Set new timestamp for added files
     for path in added_files {
-        let full_path = repo_root.join(path);
+        let full_path = repo_relative_path(repo_root, path)?;
         set_file_mtime(&full_path, new_mtime)?;
     }
 

--- a/src/timestamp/tests.rs
+++ b/src/timestamp/tests.rs
@@ -1,12 +1,14 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use tempfile::TempDir;
 
 use crate::state::{FileState, StateMetadata};
+use crate::error::HoldError;
 use crate::timestamp::{
-    generate_monotonic_timestamp, restore_timestamps, set_file_mtime, system_time_to_nanos,
+    generate_monotonic_timestamp, restore_timestamps, set_file_mtime, validate_repo_relative_path,
+    system_time_to_nanos,
 };
 
 #[test]
@@ -143,4 +145,17 @@ fn test_set_mtime_read_only_file() {
 
     let result = set_file_mtime(&test_file, SystemTime::now());
     assert!(matches!(result, Err(HoldError::SetTimestampError { .. })));
+}
+
+#[test]
+fn test_validate_repo_relative_path_rejects_escape() {
+    assert!(validate_repo_relative_path(Path::new("src/lib.rs")).is_ok());
+    assert!(matches!(
+        validate_repo_relative_path(Path::new("../etc/passwd")),
+        Err(HoldError::InvalidPath { .. })
+    ));
+    assert!(matches!(
+        validate_repo_relative_path(Path::new("/etc/passwd")),
+        Err(HoldError::InvalidPath { .. })
+    ));
 }

--- a/src/timestamp/tests.rs
+++ b/src/timestamp/tests.rs
@@ -4,11 +4,11 @@ use std::time::{Duration, SystemTime};
 
 use tempfile::TempDir;
 
-use crate::state::{FileState, StateMetadata};
 use crate::error::HoldError;
+use crate::state::{FileState, StateMetadata};
 use crate::timestamp::{
-    generate_monotonic_timestamp, restore_timestamps, set_file_mtime, validate_repo_relative_path,
-    system_time_to_nanos,
+    generate_monotonic_timestamp, restore_timestamps, set_file_mtime, system_time_to_nanos,
+    validate_repo_relative_path,
 };
 
 #[test]


### PR DESCRIPTION
hey team, was poking at cargo-hold for a ci setup and found a few things that bit me in ways that are easy to miss because the job still exits 0.

**stow / salvage silently succeeding with bad metadata**

if even one tracked file fails to hash (permissions, transient io, whatever), the commands logged a warning and returned `Ok(())`. stow still wrote metadata missing those files; salvage skipped them. cron sees green, incremental compile is wrong, nobody gets paged. now either command bails with a non-zero exit and a count of what failed.

**heave deleting a cache you just restored**

`preserve_previous_build_artifacts` compares artifact mtimes to `last_gc_mtime_nanos`. that works when mtimes survived the cache tarball. a lot of runners do not: everything in `target/` looks ancient compared to last heave, so the "previous build" guard does nothing and size/age gc throws away the artifacts you literally just restored. `rejuvenate_stale_artifact_mtimes` detects that pattern (metadata says we heaved recently, zero artifacts pass the cutoff) and bumps artifact mtimes before selection runs.

**path escape from cached metadata**

`restore_timestamps` joined `file_state.path` from the rkyv blob without checking for `..`. poisoned or hand-edited metadata could touch files outside the repo. we now reject absolute paths and parent-dir components before setting mtimes.

## test plan

- [ ] `cargo nextest run` on ubuntu + macos (ci)
- [ ] fresh repo: `cargo hold voyage` then build, second run should still hit incremental cache
- [ ] chmod a tracked source unreadable, `cargo hold anchor` should exit non-zero

cheers