### PR TITLE
ci: attest release binaries

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
-  contents: write
-  discussions: write
+  contents: read
 
 jobs:
   test:
@@ -40,6 +39,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [cross-build]
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - run: echo ${{ secrets.CRATES_IO_TOKEN }} | cargo login
@@ -100,6 +104,11 @@ jobs:
           # List all created files
           echo "Release assets:"
           ls -la *.tar.gz cargo-hold-checksums-sha256.txt
+
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: artifacts/*.tar.gz
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestation generation to the release publish workflow so published cargo-hold binary archives get provenance attestations before they are attached to the GitHub release.

## User Impact

Users and operators downloading release binaries can verify that the tarball artifacts were produced by this repository's release workflow.

## Root Cause

The publish workflow built and uploaded release archives plus checksums, but it did not request GitHub's attestation permissions or run `actions/attest` for the downloadable binaries.

## Fix

Moves broad write permissions off the workflow default, grants the publish job the release and attestation permissions it needs, and runs `actions/attest@v4` against `artifacts/*.tar.gz` after release assets are prepared and before the release is created.

## Validation

- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yaml"); puts "publish.yaml parses"'`
- `mise x actionlint@1.7.9 -- actionlint -shellcheck= .github/workflows/publish.yaml`
