### PR TITLE
fix: satisfy manual checked division lint

### DIFF
--- a/src/gc/auto_cap.rs
+++ b/src/gc/auto_cap.rs
@@ -56,11 +56,10 @@ pub(crate) fn suggest_max_target_size(
         // If observed growth (based on finals) is within a deadband, hold the cap
         // steady.
         let observed_p90 = percentile(&final_growths, 90);
-        let growth_pct = if baseline == 0 {
-            0
-        } else {
-            observed_p90.saturating_mul(100) / baseline
-        };
+        let growth_pct = observed_p90
+            .saturating_mul(100)
+            .checked_div(baseline)
+            .unwrap_or(0);
 
         if observed_p90 == 0 {
             // No observed positive growth; hold steady when baseline is at/above the cap,
@@ -102,11 +101,10 @@ pub(crate) fn suggest_max_target_size(
         }
     }
 
-    let observed_growth_pct = if baseline == 0 {
-        0
-    } else {
-        percentile(&final_growths, 90).saturating_mul(100) / baseline.max(1)
-    };
+    let observed_growth_pct = percentile(&final_growths, 90)
+        .saturating_mul(100)
+        .checked_div(baseline)
+        .unwrap_or(0);
 
     Some((
         proposed,


### PR DESCRIPTION
## Summary

Replace the manual baseline zero-check division in GC auto-cap growth calculations with `checked_div(...).unwrap_or(0)` so the crate remains clean under `-D clippy::manual-checked-ops`.

## User Impact

CI lint jobs can pass again without weakening warning enforcement or changing the zero-baseline behavior used by the cap trace calculations.

## Root Cause

The growth percentage logic guarded division with an explicit `if baseline == 0` branch, which Clippy now flags as `manual_checked_ops` when warnings are denied.

## Fix

Use checked division for both growth percentage calculations and preserve the previous fallback of `0` when the denominator is unavailable.

## Validation

- `cargo clippy --all-targets -- -D warnings`
